### PR TITLE
Port CPU plugin to Einsums 2.x

### DIFF
--- a/einhf/CMakeLists.txt
+++ b/einhf/CMakeLists.txt
@@ -79,7 +79,7 @@ target_compile_options(einhf BEFORE PUBLIC $<$<CONFIG:Debug>:$<$<COMPILE_LANG_AN
 target_compile_options(einhf BEFORE PUBLIC $<$<CONFIG:Debug>:$<$<COMPILE_LANG_AND_ID:HIP,Clang>:-O0 -gdwarf-4 -g3 -ggdb>>)
 target_compile_options(einhf BEFORE PUBLIC $<$<CONFIG:Debug>:$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Og -g3>>)
 
-target_link_libraries(einhf PUBLIC Einsums::einsums)
+target_link_libraries(einhf PUBLIC Einsums::Einsums)
 target_include_directories(einhf PUBLIC ${Einsums_INCLUDE_DIRS})
 
 get_property(fmt_INCLUDE_DIRS TARGET fmt::fmt PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/einhf/plugin.cc
+++ b/einhf/plugin.cc
@@ -30,6 +30,7 @@
 
 #include "rhf.h"
 #include "uhf.h"
+#include "Einsums/Runtime.hpp"
 #include <memory>
 
 #ifdef __HIP__
@@ -119,7 +120,7 @@ extern "C" PSI_API SharedWavefunction einhf(SharedWavefunction ref_wfn,
   }
 
   psi::outfile->Printf("Initializing Einsums.\n");
-  einsums::initialize();
+  einsums::initialize(0, (char const *const *)nullptr);
   if ((to_lower(options.get_str("REFERENCE")) == "rhf" ||
        to_lower(options.get_str("REFERENCE")) == "rks") &&
       to_lower(options.get_str("COMPUTE")) == "cpu") {
@@ -225,7 +226,7 @@ extern "C" PSI_API SharedWavefunction einhf(SharedWavefunction ref_wfn,
           "Can not handle MP2 with the given reference or compute type!");
     }
   } else if (to_lower(options.get_str("METHOD")) == "scf") {
-    einsums::finalize(false);
+    einsums::finalize();
     return outwfn;
   } else {
     throw PSIEXCEPTION("Unrecognized method" + options.get_str("METHOD"));

--- a/einhf/rhf.cc
+++ b/einhf/rhf.cc
@@ -30,7 +30,8 @@
 
 #include "rhf.h"
 
-#include "einsums.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 
 #include "psi4/libfock/jk.h"
 #include "psi4/libfock/v.h"
@@ -47,9 +48,7 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
-#include <LinearAlgebra.hpp>
-#include <_Common.hpp>
-#include <_Index.hpp>
+#include <Einsums/LinearAlgebra.hpp>
 #include <cmath>
 
 static std::string to_lower(const std::string &str) {
@@ -428,12 +427,12 @@ double EinsumsRHF::compute_electronic_energy() {
   temp += JKwK_;
 
   einsums::tensor_algebra::einsum(
-      0.0, einsums::tensor_algebra::Indices{}, &e_tens, 1.0,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      0.0, einsums::Indices{}, &e_tens, 1.0,
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       D_,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       temp);
 
   double out = (double)e_tens;
@@ -597,14 +596,14 @@ double EinsumsRHF::compute_energy() {
 
   timer_on("Form D");
   einsums::tensor_algebra::einsum(
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       &D_,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::m},
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::m},
       Cocc_,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::j,
-                                       einsums::tensor_algebra::index::m},
+      einsums::Indices{einsums::index::j,
+                                       einsums::index::m},
       Cocc_);
   timer_off("Form D");
 
@@ -856,13 +855,13 @@ double EinsumsRHF::compute_energy() {
       }
 
       einsums::tensor_algebra::einsum(
-          0.0, einsums::tensor_algebra::Indices{}, dRMS_tens,
+          0.0, einsums::Indices{}, dRMS_tens,
           1.0 / (nso_ * nso_),
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           *Temp1,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           *Temp1);
 
 // Compute the energy
@@ -897,14 +896,14 @@ double EinsumsRHF::compute_energy() {
 
     timer_on("Form D");
     einsums::tensor_algebra::einsum(
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                         einsums::tensor_algebra::index::j},
+        einsums::Indices{einsums::index::i,
+                                         einsums::index::j},
         &D_,
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                         einsums::tensor_algebra::index::m},
+        einsums::Indices{einsums::index::i,
+                                         einsums::index::m},
         Cocc_,
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::j,
-                                         einsums::tensor_algebra::index::m},
+        einsums::Indices{einsums::index::j,
+                                         einsums::index::m},
         Cocc_);
     timer_off("Form D");
 
@@ -1086,7 +1085,7 @@ void EinsumsRHF::print_header() {
   basisset_->print_by_level("outfile", print_);
 
   outfile->Printf("  ==> Functional <==\n\n");
-  func_->print("outfile", print_);
+  outfile->Printf("    %s\n\n", func_->name().c_str());
 }
 } // namespace einhf
 } // namespace psi

--- a/einhf/rhf.h
+++ b/einhf/rhf.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "einsums.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 #include <deque>
 #include <vector>
 

--- a/einhf/rmp2.cc
+++ b/einhf/rmp2.cc
@@ -31,8 +31,8 @@
 #include "rmp2.h"
 #include "rhf.h"
 
-#include "einsums.hpp"
-#include "einsums/Tensor.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 
 #include "psi4/libfock/jk.h"
 #include "psi4/libfock/v.h"
@@ -50,9 +50,7 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
-#include <LinearAlgebra.hpp>
-#include <_Common.hpp>
-#include <_Index.hpp>
+#include <Einsums/LinearAlgebra.hpp>
 #include <cmath>
 
 static std::string to_lower(const std::string &str) {

--- a/einhf/rmp2.h
+++ b/einhf/rmp2.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "einsums.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 #include <deque>
 #include <vector>
 
@@ -46,8 +47,7 @@ class JK;
 namespace einhf {
 
 struct MP2ScaleFunction
-    : public virtual einsums::tensor_props::FunctionTensorBase<double, 4>,
-      virtual einsums::tensor_props::CoreTensorBase {
+    : public virtual einsums::tensor_base::FunctionTensor<double, 4> {
 private:
   einsums::Tensor<double, 1> _evalsi, _evalsa, _evalsj, _evalsb;
 
@@ -59,26 +59,26 @@ public:
                    const einsums::TensorView<double, 1> &evalsa,
                    const einsums::TensorView<double, 1> &evalsj,
                    const einsums::TensorView<double, 1> &evalsb)
-      : einsums::tensor_props::FunctionTensorBase<double, 4>(
+      : einsums::tensor_base::FunctionTensor<double, 4>(
             name, evalsi.dim(0), evalsa.dim(0), evalsj.dim(0), evalsb.dim(0)),
         _evalsi(evalsi), _evalsa(evalsa), _evalsj(evalsj), _evalsb(evalsb) {}
 
-  double call(const std::array<int, 4> &inds) const override {
+  double call(const std::array<ptrdiff_t, 4> &inds) const override {
     return 1.0 / ((_evalsi)(inds[0]) + (_evalsj)(inds[2]) - (_evalsa)(inds[1]) -
                   (_evalsb)(inds[3]));
   }
 };
 
 struct RMP2ScaleTensor final
-    : public virtual einsums::tensor_props::TiledTensorBase<double, 4,
-                                                            MP2ScaleFunction>,
-      virtual einsums::tensor_props::CoreTensorBase {
+    : public virtual einsums::tensor_base::TiledTensor<double, 4,
+                                                       MP2ScaleFunction>,
+      virtual einsums::tensor_base::CoreTensor {
 private:
   const einsums::Tensor<double, 1> *_evals;
   std::vector<int> _irrep_offsets, _irrep_sizes;
   std::vector<std::string> _irrep_names;
 
-  virtual void add_tile(std::array<int, 4> pos) override {
+  virtual void add_tile(std::array<int, 4> const &pos) override {
     std::string tile_name = name() + " - (";
     einsums::Dim<4> dims{};
 
@@ -120,7 +120,7 @@ public:
                   std::vector<int> irrep_sizes,
                   std::vector<std::string> irrep_names,
                   const einsums::Tensor<double, 1> *evals)
-      : einsums::tensor_props::TiledTensorBase<double, 4, MP2ScaleFunction>(
+      : einsums::tensor_base::TiledTensor<double, 4, MP2ScaleFunction>(
             name, occupied, unoccupied, occupied, unoccupied),
         _irrep_offsets(irrep_offsets), _irrep_sizes(irrep_sizes),
         _irrep_names(irrep_names), _evals{evals} {}

--- a/einhf/uhf.cc
+++ b/einhf/uhf.cc
@@ -30,7 +30,8 @@
 
 #include "uhf.h"
 
-#include "einsums.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 
 #include "psi4/libfock/jk.h"
 #include "psi4/libfock/v.h"
@@ -45,9 +46,7 @@
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
-#include <LinearAlgebra.hpp>
-#include <_Common.hpp>
-#include <_Index.hpp>
+#include <Einsums/LinearAlgebra.hpp>
 
 using namespace einsums;
 
@@ -372,12 +371,12 @@ double EinsumsUHF::compute_electronic_energy(
   temp += JKwK;
 
   einsums::tensor_algebra::einsum(
-      0.0, einsums::tensor_algebra::Indices{}, &e_tens, 1.0,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      0.0, einsums::Indices{}, &e_tens, 1.0,
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       D,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       temp);
   double out = (double)e_tens;
 
@@ -630,14 +629,14 @@ double EinsumsUHF::compute_energy() {
   {
     timer_on("Form Da");
     einsums::tensor_algebra::einsum(
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                         einsums::tensor_algebra::index::j},
+        einsums::Indices{einsums::index::i,
+                                         einsums::index::j},
         &Da_,
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                         einsums::tensor_algebra::index::m},
+        einsums::Indices{einsums::index::i,
+                                         einsums::index::m},
         Cocca_,
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::j,
-                                         einsums::tensor_algebra::index::m},
+        einsums::Indices{einsums::index::j,
+                                         einsums::index::m},
         Cocca_);
     timer_off("Form Da");
   }
@@ -646,14 +645,14 @@ double EinsumsUHF::compute_energy() {
   {
     timer_on("Form Db");
     einsums::tensor_algebra::einsum(
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                         einsums::tensor_algebra::index::j},
+        einsums::Indices{einsums::index::i,
+                                         einsums::index::j},
         &Db_,
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                         einsums::tensor_algebra::index::m},
+        einsums::Indices{einsums::index::i,
+                                         einsums::index::m},
         Coccb_,
-        einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::j,
-                                         einsums::tensor_algebra::index::m},
+        einsums::Indices{einsums::index::j,
+                                         einsums::index::m},
         Coccb_);
     timer_off("Form Db");
   }
@@ -1123,26 +1122,26 @@ double EinsumsUHF::compute_energy() {
 #pragma omp task depend(in : *Temp1a) depend(out : *dRMS_tensa)
     {
       einsums::tensor_algebra::einsum(
-          0.0, einsums::tensor_algebra::Indices{}, dRMS_tensa,
+          0.0, einsums::Indices{}, dRMS_tensa,
           1.0 / (nso_ * nso_),
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           *Temp1a,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           *Temp1a);
     }
 
 #pragma omp task depend(in : *Temp1b) depend(out : *dRMS_tensb)
     {
       einsums::tensor_algebra::einsum(
-          0.0, einsums::tensor_algebra::Indices{}, dRMS_tensb,
+          0.0, einsums::Indices{}, dRMS_tensb,
           1.0 / (nso_ * nso_),
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           *Temp1b,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           *Temp1b);
     }
 
@@ -1249,14 +1248,14 @@ double EinsumsUHF::compute_energy() {
     {
       timer_on("Form Da");
       einsums::tensor_algebra::einsum(
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           &Da_,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::m},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::m},
           Cocca_,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::j,
-                                           einsums::tensor_algebra::index::m},
+          einsums::Indices{einsums::index::j,
+                                           einsums::index::m},
           Cocca_);
       timer_off("Form Da");
     }
@@ -1265,14 +1264,14 @@ double EinsumsUHF::compute_energy() {
     {
       timer_on("Form Db");
       einsums::tensor_algebra::einsum(
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::j},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::j},
           &Db_,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                           einsums::tensor_algebra::index::m},
+          einsums::Indices{einsums::index::i,
+                                           einsums::index::m},
           Coccb_,
-          einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::j,
-                                           einsums::tensor_algebra::index::m},
+          einsums::Indices{einsums::index::j,
+                                           einsums::index::m},
           Coccb_);
       timer_off("Form Db");
     }
@@ -1320,21 +1319,21 @@ double EinsumsUHF::compute_energy() {
   einsums::Tensor<double, 0> spin;
 
   einsums::tensor_algebra::einsum(
-      0.0, einsums::tensor_algebra::Indices{}, &spin, 0.5,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      0.0, einsums::Indices{}, &spin, 0.5,
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       Da_,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       Da_);
 
   einsums::tensor_algebra::einsum(
-      1.0, einsums::tensor_algebra::Indices{}, &spin, -0.5,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      1.0, einsums::Indices{}, &spin, -0.5,
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       Db_,
-      einsums::tensor_algebra::Indices{einsums::tensor_algebra::index::i,
-                                       einsums::tensor_algebra::index::j},
+      einsums::Indices{einsums::index::i,
+                                       einsums::index::j},
       Db_);
 
   double s_squared = (double)spin * ((double)spin + 1);
@@ -1526,7 +1525,7 @@ void EinsumsUHF::print_header() {
   basisset_->print_by_level("outfile", print_);
 
   outfile->Printf("  ==> Functional <==\n\n");
-  func_->print("outfile", print_);
+  outfile->Printf("    %s\n\n", func_->name().c_str());
 }
 } // namespace einhf
 } // namespace psi

--- a/einhf/uhf.h
+++ b/einhf/uhf.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "einsums.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 #include <deque>
 #include <vector>
 

--- a/einhf/ump2.cc
+++ b/einhf/ump2.cc
@@ -31,8 +31,8 @@
 #include "ump2.h"
 #include "uhf.h"
 
-#include "einsums.hpp"
-#include "einsums/Tensor.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 
 #include "psi4/libfock/jk.h"
 #include "psi4/libfock/v.h"
@@ -50,9 +50,7 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
-#include <LinearAlgebra.hpp>
-#include <_Common.hpp>
-#include <_Index.hpp>
+#include <Einsums/LinearAlgebra.hpp>
 #include <cmath>
 
 static std::string to_lower(const std::string &str) {

--- a/einhf/ump2.h
+++ b/einhf/ump2.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "einsums.hpp"
+#include "Einsums/Tensor.hpp"
+#include "Einsums/TensorAlgebra.hpp"
 #include <deque>
 #include <vector>
 
@@ -47,15 +48,15 @@ class JK;
 namespace einhf {
 
 struct UMP2ScaleTensor final
-    : public virtual einsums::tensor_props::TiledTensorBase<double, 4,
-                                                            MP2ScaleFunction>,
-      virtual einsums::tensor_props::CoreTensorBase {
+    : public virtual einsums::tensor_base::TiledTensor<double, 4,
+                                                       MP2ScaleFunction>,
+      virtual einsums::tensor_base::CoreTensor {
 private:
   const einsums::Tensor<double, 1> *_aevals, *_bevals;
   std::vector<int> _irrep_offsets, _irrep_sizes;
   std::vector<std::string> _irrep_names;
 
-  virtual void add_tile(std::array<int, 4> pos) override {
+  virtual void add_tile(std::array<int, 4> const &pos) override {
     std::string tile_name = name() + " - (";
     einsums::Dim<4> dims{};
 
@@ -99,7 +100,7 @@ public:
                   std::vector<std::string> irrep_names,
                   const einsums::Tensor<double, 1> *aevals,
                   const einsums::Tensor<double, 1> *bevals)
-      : einsums::tensor_props::TiledTensorBase<double, 4, MP2ScaleFunction>(
+      : einsums::tensor_base::TiledTensor<double, 4, MP2ScaleFunction>(
             name, aoccupied, aunoccupied, boccupied, bunoccupied),
         _irrep_offsets(irrep_offsets), _irrep_sizes(irrep_sizes),
         _irrep_names(irrep_names), _aevals{aevals}, _bevals{bevals} {}

--- a/einhf/water_cpu.in
+++ b/einhf/water_cpu.in
@@ -1,0 +1,31 @@
+
+# PYTHONPATH must include directory above plugin directory.
+#     Define either externally or here, then import plugin.
+sys.path.insert(0, './..')
+import einhf
+
+memory 12 GB
+
+molecule water {
+  O
+  H 1 1.1
+  H 1 1.1 2 104.5
+}
+
+set basis cc-pVTZ
+
+set GUESS CORE
+set DIIS TRUE
+set SCF_INITIAL_ACCELERATOR NONE
+set PRINT 1
+set SCF_TYPE PK
+set COMPUTE CPU
+set MP2_TYPE CONV
+
+set reference uhf
+
+E1 = energy("mp2")
+
+E2 = energy("einmp2")
+
+assert(abs(E2 - E1) < 1e-6)


### PR DESCRIPTION
## Summary
- Migrate CPU sources to Einsums 2.x: header reshuffle (Tensor.hpp / TensorAlgebra.hpp / Runtime.hpp / LinearAlgebra.hpp), `tensor_props::*Base` → `tensor_base::*` with the `CoreTensor` diamond fix on the MP2 scale tensors, `einsums::tensor_algebra::Indices` → `einsums::Indices`, and new `initialize`/`finalize` signatures.
- Bump CMake target to `Einsums::Einsums`; work around a Psi4 1.10 `SuperFunctional::print()` crash in `print_header()`. GPU sources are intentionally untouched.
- Add `water_cpu.in`, a CPU mirror of `water.in` (the existing `water.in` still selects `COMPUTE GPU`).

## Test plan
- [x] `make` builds `einhf.so` cleanly with `BUILD_GPU=OFF`
- [x] `psi4 water_cpu.in` → UMP2 = -76.303023, matches Psi4 reference to <1e-6, assertion passes
- [ ] GPU build (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)